### PR TITLE
Fix-codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,10 +14,10 @@ coverage:
         threshold: 0%
         base: auto
     # Not ready to start using blocking status checks? Set them as informational!
-        informational: true
-    patch:
-      default:
-        informational: true
+    #     informational: true
+    # patch:
+    #   default:
+    #     informational: true
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
- comment out informational flag for default and patch coverage checks