### PR TITLE
👷 ci(codecov): make status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,10 +14,10 @@ coverage:
         threshold: 0%
         base: auto
     # Not ready to start using blocking status checks? Set them as informational!
-    #     informational: true
-    # patch:
-    #   default:
-    #     informational: true
+        informational: true
+    patch:
+      default:
+        informational: true
 
 comment:
   layout: "diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,10 +14,10 @@ coverage:
         threshold: 0%
         base: auto
     # Not ready to start using blocking status checks? Set them as informational!
-        informational: true
-    patch:
-      default:
-        informational: true
+        # informational: true
+    # patch:
+      # default:
+        # informational: true
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
- enable informational status checks for default project coverage
- enable informational status checks for patch coverage
- allow CI builds to pass even if coverage thresholds are not met